### PR TITLE
viewer: use .RelPermalink

### DIFF
--- a/layouts/shortcodes/viewer.html
+++ b/layouts/shortcodes/viewer.html
@@ -1,1 +1,1 @@
-<iframe src="/ViewerJS/#{{ .Page.Permalink | safeURL }}{{ .Get 0 }}" width='400' height='300' allowfullscreen webkitallowfullscreen></iframe>
+<iframe src="/ViewerJS/#{{ .Page.RelPermalink | safeURL }}{{ .Get 0 }}" width='400' height='300' allowfullscreen webkitallowfullscreen></iframe>


### PR DESCRIPTION
Update .Permalink to .RelPermalink to fix ViewerJS issues in `viewer` shortcode